### PR TITLE
Refactoring KV unit tests:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ keywords = ["consul", "discovery"]
 
 
 [dependencies]
+base64 = "0.12.1"
 error-chain = "0.12"
 serde = "1"
 serde_derive = "1"
 serde_json = "1.0"
+rand = "0.7.3"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 url = "2.1"


### PR DESCRIPTION
    * Creating setup and tear down methods to create unique kv path for
      each test and clean up afterwards
    * Adding individual tests for each of the following functionalities:
        * Add
        * Delete
        * Get
        * List
        * Put