### PR TITLE
Refactoring health unit tests:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ error-chain = "0.12"
 serde = "1"
 serde_derive = "1"
 serde_json = "1.0"
+rand = "0.7.3"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 url = "2.1"

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,27 +1,58 @@
 extern crate consul;
 use consul::{Client, Config};
+use consul::health::Health;
+
+extern crate rand;
+use rand::{thread_rng, Rng};
+use rand::distributions::Alphanumeric;
 
 #[test]
-fn health_test() {
-    use consul::health::Health;
+fn health_service_test_passing_only() {
+    let client = set_up();
+
+    let (service_entries, query_meta) = client
+        .service(
+            "consul",
+            Option::None,
+            true,
+            Option::None)
+        .unwrap();
+
+    assert_eq!(service_entries.len(), 1);
+
+    let service_entry = service_entries
+        .iter()
+        .next()
+        .unwrap();
+
+    assert_eq!(service_entry.Service.Service, "consul");
+    assert!(query_meta.last_index.unwrap() > 0, "index must be positive");
+}
+
+#[test]
+fn health_service_test_non_existant() {
+    let client = set_up();
+
+    let non_existant_service_name: String = thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(16)
+        .collect();
+
+    let (service_entries, meta_query) = client
+        .service(
+            &non_existant_service_name,
+            Option::None,
+            true,
+            Option::None)
+        .unwrap();
+
+    assert_eq!(service_entries.len(), 0);
+    assert!(meta_query.last_index.unwrap() > 0, "index must be positive");
+}
+
+fn set_up() -> Client {
     let config = Config::new().unwrap();
     let client = Client::new(config);
-    // An existing service for a agent in dev mode
-    let r = client
-        .service("consul", Option::None, true, Option::None)
-        .unwrap();
-    let (snodes, meta) = (r.0, r.1);
-    {
-        assert!(snodes.len() > 0, "should have at least one Service Node");
-        assert!(meta.last_index.unwrap() > 0, "index must be positive");
-    }
-    // A non existing, should be empty
-    let r = client
-        .service("non-existing-service", Option::None, true, Option::None)
-        .unwrap();
-    let (snodes, meta) = (r.0, r.1);
-    {
-        assert_eq!(snodes.len(), 0);
-        assert!(meta.last_index.unwrap() > 0, "index must be positive");
-    }
+
+    return client;
 }


### PR DESCRIPTION
    * Creating set_up method for client creation
    * Adding unit tests to test scenario when service exists, and when
      service doesnt exist